### PR TITLE
better error message and full code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ func main() {
 
 	failure, err := dig.Dig(v, "foo", "qux", "quux")
 	if err != nil {
-		// key qux not found in <nil>
+		// key qux not found in map[bar:map[baz:1]]
 		fmt.Println(err)
 	}
 	// foo.qux.quux = <nil>

--- a/dig.go
+++ b/dig.go
@@ -8,23 +8,25 @@ import (
 func Dig(v interface{}, keys ...interface{}) (interface{}, error) {
 	n := len(keys)
 	for i, key := range keys {
-		stringKey, ok := key.(string)
-		if ok {
+		// try lookup with string key
+		if stringKey, ok := key.(string); ok {
 			raw, ok := v.(map[string]interface{})
 			if !ok {
 				return nil, fmt.Errorf("%v isn't a map", v)
 			}
-			v, ok = raw[stringKey]
+			found, ok := raw[stringKey]
 			if !ok {
 				return nil, fmt.Errorf("key %v not found in %v", stringKey, v)
 			}
+			v = found
 			if i == n-1 {
 				return v, nil
 			}
 			continue
 		}
-		intKey, ok := key.(int)
-		if ok {
+
+		// try lookup with int key
+		if intKey, ok := key.(int); ok {
 			raw, ok := v.([]interface{})
 			if !ok {
 				return nil, fmt.Errorf("%v isn't a slice", v)
@@ -38,7 +40,10 @@ func Dig(v interface{}, keys ...interface{}) (interface{}, error) {
 			}
 			continue
 		}
+
+		// not a supported key format
 		return nil, fmt.Errorf("unsupported key type: %v", key)
 	}
-	return nil, fmt.Errorf("no key is given")
+
+	return nil, fmt.Errorf("no key given")
 }


### PR DESCRIPTION
### Error

before: `key qux not found in nil` ... that's just wrong
after: `key qux not found in map[bar:map[baz:1]]`


### Coverage

before:
```
go-testcov .
ok  	github.com/mnogu/go-dig	0.456s	coverage: 92.3% of statements
dig.go new untested sections introduced (2 current vs 0 configured)
dig.go:41.3,41.58
dig.go:43.2,43.43
```

after 🎉 